### PR TITLE
Update im rtd module

### DIFF
--- a/test/spec/modules/imRtdProvider_spec.js
+++ b/test/spec/modules/imRtdProvider_spec.js
@@ -1,6 +1,7 @@
 import {
   imRtdSubmodule,
   storage,
+  getBidderFunction,
   getCustomBidderFunction,
   setRealTimeData,
   getRealTimeData,
@@ -45,6 +46,30 @@ describe('imRtdProvider', function () {
     it('should initalise and return true', function () {
       expect(imRtdSubmodule.init()).to.equal(true)
     })
+  })
+
+  describe('getBidderFunction', function () {
+    const assumedBidder = [
+      'ix',
+      'pubmatic'
+    ];
+    assumedBidder.forEach(bidderName => {
+      it(`should return bidderFunction with assumed bidder: ${bidderName}`, function () {
+        expect(getBidderFunction(bidderName)).to.exist.and.to.be.a('function');
+      });
+
+      it(`should return bid with correct key data: ${bidderName}`, function () {
+        const bid = {bidder: bidderName};
+        expect(getBidderFunction(bidderName)(bid, {'im_segments': ['12345', '67890']})).to.equal(bid);
+      });
+      it(`should return bid without data: ${bidderName}`, function () {
+        const bid = {bidder: bidderName};
+        expect(getBidderFunction(bidderName)(bid, '')).to.equal(bid);
+      });
+    });
+    it(`should return null with unexpected bidder`, function () {
+      expect(getBidderFunction('test')).to.equal(null);
+    });
   })
 
   describe('getCustomBidderFunction', function () {


### PR DESCRIPTION
ix, pubmatic用の関数追加
# ix
## 設定箇所
```js
pbjs.getConfig().ix
```
## 参考
https://github.com/IntimateMerger/pmt.js/blob/master/src/lib/prebid.ts#L36-L42
同じように設定
![image](https://user-images.githubusercontent.com/7745568/138442056-c837efb5-41bf-42c4-8107-232e684d2174.png)

# pubmatic
## 設定箇所
```js
pbjs.adUnits[0].bids //の何番目か
```
## 参考
https://github.com/prebid/Prebid.js/blob/master/test/spec/modules/pubmaticBidAdapter_spec.js
このあたりを見て正しそうか確認
設定値がstringになるため `,` 区切りにしています

![image](https://user-images.githubusercontent.com/7745568/138442242-bf28a5fc-02b4-4bd4-9172-037f980357fb.png)

# coverage
![image](https://user-images.githubusercontent.com/7745568/138446103-0703bccf-e636-407d-9e31-e3f526d99540.png)